### PR TITLE
update architecture for turing and xp, and repo link in the docs

### DIFF
--- a/introduction/architecture/experiments-architecture.md
+++ b/introduction/architecture/experiments-architecture.md
@@ -1,3 +1,7 @@
 # Experiments Architecture
 
-The overall view of the system architecture of CaraML Experiments is work is progress, stay tuned!
+The overall view of the system architecture of CaraML Experiment engine can be illustrated in the diagram below:
+
+![Experiments architecture](../../module/experiment/assets/xp_architecture.png)
+
+You may refer to more details in the [repository](https://github.com/caraml-dev/xp) over here.

--- a/introduction/architecture/feature-store-architecture.md
+++ b/introduction/architecture/feature-store-architecture.md
@@ -2,6 +2,6 @@
 
 The overall view of the system architecture of CaraML Feature Store can be illustrated in the diagram below:
 
-![Feature Store architecture](../../.gitbook/assets/feast\_architecture.png)
+![Feature Store architecture](../../.gitbook/assets/feast_architecture.png)
 
 You may refer to more details in the [repository](https://github.com/caraml-dev/caraml-store) over here.

--- a/introduction/architecture/feature-store-architecture.md
+++ b/introduction/architecture/feature-store-architecture.md
@@ -3,3 +3,5 @@
 The overall view of the system architecture of CaraML Feature Store can be illustrated in the diagram below:
 
 ![Feature Store architecture](../../.gitbook/assets/feast\_architecture.png)
+
+You may refer to more details in the [repository](https://github.com/caraml-dev/caraml-store) over here.

--- a/introduction/architecture/pipelines-architecture.md
+++ b/introduction/architecture/pipelines-architecture.md
@@ -2,4 +2,4 @@
 
 The overall view of the system architecture of CaraML Pipelines can be illustrated in the diagram below:
 
-![Pipelines Architecture](../../.gitbook/assets/dap\_architecture.png)
+![Pipelines Architecture](../../.gitbook/assets/dap_architecture.png)

--- a/introduction/architecture/routers-architecture.md
+++ b/introduction/architecture/routers-architecture.md
@@ -2,4 +2,6 @@
 
 The overall view of the system architecture of CaraML Traffic Routers can be illustrated in the diagram below:
 
-![Routers architecture](../../.gitbook/assets/turing\_architecture.png)
+![Routers architecture](../../module/router/assets/turing_architecture.png)
+
+You may refer to more details in the [repository](https://github.com/caraml-dev/turing) over here.


### PR DESCRIPTION
Hey folks, 

I realised for these 2 docs, somehow they are not synced to the central caraml docs repo. 
[Turing repo readme](https://github.com/caraml-dev/turing/blob/main/README.md)
[Turing XP repo readme](https://github.com/caraml-dev/xp/blob/main/README.md)

I was looking for a architecture diagram when I first started building the docs, I think I missed it, and we only use github actions to sync the “/docs” into the "/modules" folder here, so these are not found for the overall [caraml docs](https://docs.caraml.dev/introduction/architecture/routers-architecture). 

For now I included these into the respective "architecture" pages. We might want to consider syncing the readmes into the doc repo or have a dedicated architecture.md file similar to Merlin [here](https://github.com/caraml-dev/merlin/blob/main/docs/dev-guide/architecture.md). 